### PR TITLE
Remove useless blocks

### DIFF
--- a/Sentry.xml
+++ b/Sentry.xml
@@ -3,8 +3,8 @@
 <script type="text/javascript" src="../../blocks/company/Sentry.js"></script>
 <script type="text/javascript" src="../../generators/arduino/company/Sentry.js"></script>
 <category id="mixly_Sentry" name="Sentry" colour="#EF5411">
-  <category id="morpxSentry_Setup" name="设置模块" colour="#EF5411">
-    <block type="SentrySetup">
+  <category id="Sentry_Setup" name="设置模块" colour="#EF5411">
+    <!-- <block type="SentrySetup">
       <statement name="SENTRY_SETUP_BLOCK">
         <block type="SentryBegin">
           <field name="sentry_obj">0</field>
@@ -22,7 +22,7 @@
           </next>
         </block>
       </statement>
-    </block>    <!-- 初始化 Sentry -->
+    </block>    初始化 Sentry -->
     <block type="SentryBegin"></block>    <!-- 设置 恢复默认设置-->
     <block type="SentrySetDefault"></block>    <!-- 设置 坐标系设置-->
     <block type="SentrySetCoordinateType"></block>    <!-- 启用算法-->
@@ -31,15 +31,16 @@
     <block type="SentryVisionColorSetParam"></block>
     <block type="SentryVisionBlobSetParam"></block>    <!-- block type="SentryVisionFaceSetParam"></block-->    <!-- 设置 LED-->
     <block type="SentryLedSetColor">
-      <value name="level"></value>
-      <shadow type="math_number">
-        <field name="NUM">1</field>
-      </shadow>
+      <value name="level">
+        <shadow type="math_number">
+          <field name="NUM">1</field>
+        </shadow>
+      </value>
     </block>    <!-- 设置 变焦等级-->
     <block type="SentrySetZoom"></block>    <!-- 设置 白平衡-->
     <block type="SentrySetAWB"></block>
   </category>
-  <category id="morpxSentry_Run" name="运行模块" colour="#EAA20A">
+  <category id="Sentry_Run" name="运行模块" colour="#EAA20A">
     <block type="SentryVisionGetStatus"></block>
     <block type="SentryVisionDetectedCount"></block>
     <block type="SentryGetValue">
@@ -106,352 +107,20 @@
     <block type="SentryRows"></block>
     <block type="SentryCols"></block>
   </category>
-  <category id="morpxSentry_example" name="算法示例" colour="#EAA20A">
-    <category id="Sentry_example_Color" name="颜色检测" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
-            <field name="sentry_obj">0</field>
-            <field name="mode_obj">Wire</field>
-            <next>
-              <block type="SentrySetDefault">
-                <field name="sentry_obj">0</field>
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="sentry_obj">0</field>
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="sentry_obj">0</field>
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionColor</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="sentry_obj">0</field>
-                            <field name="led_color_obj1">#00ffff</field>
-                            <field name="led_color_obj2">#ffffff</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                            <next>
-                              <block type="SentrySetZoom">
-                                <field name="sentry_obj">0</field>
-                                <field name="zoom_obj">kZoomDefault</field>
-                                <next>
-                                  <block type="SentryVisionSetParamNum">
-                                    <field name="sentry_obj">0</field>
-                                    <field name="vision_obj">Sentry2::kVisionColor</field>
-                                    <field name="num">2</field>
-                                    <next>
-                                      <block type="SentryVisionColorSetParam">
-                                        <field name="sentry_obj">0</field>
-                                        <field name="vision_obj">Sentry2::kVisionColor</field>
-                                        <field name="x">120</field>
-                                        <field name="y">120</field>
-                                        <field name="w">10</field>
-                                        <field name="h">10</field>
-                                        <field name="index">0</field>
-                                        <next>
-                                          <block type="SentryVisionColorSetParam">
-                                            <field name="sentry_obj">0</field>
-                                            <field name="vision_obj">Sentry2::kVisionColor</field>
-                                            <field name="x">160</field>
-                                            <field name="y">120</field>
-                                            <field name="w">20</field>
-                                            <field name="h">20</field>
-                                            <field name="index">1</field>
-                                          </block>
-                                        </next>
-                                      </block>
-                                    </next>
-                                  </block>
-                                </next>
-                              </block>
-                            </next>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
-              </block>
-            </next>
-          </block>
-        </statement>
-      </block>
-      <block type="variables_declare">
-        <field name="variables_type">local_variate</field>
-        <field name="VAR">count</field>
-        <field name="TYPE">int</field>
-        <value name="VALUE">
-          <block type="math_number">
-            <field name="NUM">0</field>
-          </block>
-        </value>
-        <next>
-          <block type="variables_set">
-            <field name="VAR">count</field>
-            <value name="VALUE">
-              <block type="SentryVisionDetectedCount">
-                <field name="sentry_obj">0</field>
-                <field name="vision_obj">Sentry2::kVisionColor</field>
-              </block>
-            </value>
-            <next>
-              <block type="controls_for">
-                <field name="VAR">i</field>
-                <value name="FROM">
-                  <shadow type="math_number">
-                    <field name="NUM">0</field>
-                  </shadow>
-                </value>
-                <value name="TO">
-                  <shadow type="math_number">
-                    <field name="NUM">10</field>
-                  </shadow>
-                  <block type="math_arithmetic">
-                    <field name="OP">MINUS</field>
-                    <value name="A">
-                      <shadow type="math_number">
-                        <field name="NUM">1</field>
-                      </shadow>
-                      <block type="variables_get">
-                        <field name="VAR">count</field>
-                      </block>
-                    </value>
-                    <value name="B">
-                      <shadow type="math_number">
-                        <field name="NUM">1</field>
-                      </shadow>
-                    </value>
-                  </block>
-                </value>
-                <value name="STEP">
-                  <shadow type="math_number">
-                    <field name="NUM">1</field>
-                  </shadow>
-                </value>
-                <statement name="DO">
-                  <block type="serial_print">
-                    <field name="serial_select">Serial</field>
-                    <field name="new_line">println</field>
-                    <value name="CONTENT">
-                      <block type="text_join">
-                        <value name="A">
-                          <shadow type="text">
-                            <field name="TEXT">r=</field>
-                          </shadow>
-                        </value>
-                        <value name="B">
-                          <shadow type="text">
-                            <field name="TEXT">Mixly</field>
-                          </shadow>
-                          <block type="SentryGetValue">
-                            <field name="sentry_obj">0</field>
-                            <value name="sentry_value_obj">
-                              <block type="SentryVisionObjColor">
-                                <field name="vision_obj">Sentry2::kVisionColor</field>
-                                <field name="vision_res_obj">kRValue</field>
-                              </block>
-                            </value>
-                            <value name="index">
-                              <shadow type="math_number">
-                                <field name="NUM">0</field>
-                              </shadow>
-                              <block type="variables_get">
-                                <field name="VAR">i</field>
-                              </block>
-                            </value>
-                          </block>
-                        </value>
-                      </block>
-                    </value>
-                    <next>
-                      <block type="serial_print">
-                        <field name="serial_select">Serial</field>
-                        <field name="new_line">println</field>
-                        <value name="CONTENT">
-                          <block type="text_join">
-                            <value name="A">
-                              <shadow type="text">
-                                <field name="TEXT">g=</field>
-                              </shadow>
-                            </value>
-                            <value name="B">
-                              <shadow type="text">
-                                <field name="TEXT">Mixly</field>
-                              </shadow>
-                              <block type="SentryGetValue">
-                                <field name="sentry_obj">0</field>
-                                <value name="sentry_value_obj">
-                                  <block type="SentryVisionObjColor">
-                                    <field name="vision_obj">Sentry2::kVisionColor</field>
-                                    <field name="vision_res_obj">kGValue</field>
-                                  </block>
-                                </value>
-                                <value name="index">
-                                  <shadow type="math_number">
-                                    <field name="NUM">0</field>
-                                  </shadow>
-                                  <block type="variables_get">
-                                    <field name="VAR">i</field>
-                                  </block>
-                                </value>
-                              </block>
-                            </value>
-                          </block>
-                        </value>
-                        <next>
-                          <block type="serial_print">
-                            <field name="serial_select">Serial</field>
-                            <field name="new_line">println</field>
-                            <value name="CONTENT">
-                              <block type="text_join">
-                                <value name="A">
-                                  <shadow type="text">
-                                    <field name="TEXT">b=</field>
-                                  </shadow>
-                                </value>
-                                <value name="B">
-                                  <shadow type="text">
-                                    <field name="TEXT">Mixly</field>
-                                  </shadow>
-                                  <block type="SentryGetValue">
-                                    <field name="sentry_obj">0</field>
-                                    <value name="sentry_value_obj">
-                                      <block type="SentryVisionObjColor">
-                                        <field name="vision_obj">Sentry2::kVisionColor</field>
-                                        <field name="vision_res_obj">kBValue</field>
-                                      </block>
-                                    </value>
-                                    <value name="index">
-                                      <shadow type="math_number">
-                                        <field name="NUM">0</field>
-                                      </shadow>
-                                      <block type="variables_get">
-                                        <field name="VAR">i</field>
-                                      </block>
-                                    </value>
-                                  </block>
-                                </value>
-                              </block>
-                            </value>
-                            <next>
-                              <block type="serial_print">
-                                <field name="serial_select">Serial</field>
-                                <field name="new_line">println</field>
-                                <value name="CONTENT">
-                                  <block type="text_join">
-                                    <value name="A">
-                                      <shadow type="text">
-                                        <field name="TEXT">l=</field>
-                                      </shadow>
-                                    </value>
-                                    <value name="B">
-                                      <shadow type="text">
-                                        <field name="TEXT">Mixly</field>
-                                      </shadow>
-                                      <block type="SentryGetValue">
-                                        <field name="sentry_obj">0</field>
-                                        <value name="sentry_value_obj">
-                                          <block type="SentryVisionObjColor">
-                                            <field name="vision_obj">Sentry2::kVisionColor</field>
-                                            <field name="vision_res_obj">kLabel</field>
-                                          </block>
-                                        </value>
-                                        <value name="index">
-                                          <shadow type="math_number">
-                                            <field name="NUM">0</field>
-                                          </shadow>
-                                          <block type="variables_get">
-                                            <field name="VAR">i</field>
-                                          </block>
-                                        </value>
-                                      </block>
-                                    </value>
-                                  </block>
-                                </value>
-                              </block>
-                            </next>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </statement>
-              </block>
-            </next>
-          </block>
-        </next>
-      </block>
-    </category>
+  <category id="Sentry_example" name="算法示例" colour="#EAA20A">
     <category id="Sentry_example_Blod" name="色块检测" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
-            <field name="sentry_obj">0</field>
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="329" y="125">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
+            <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <field name="sentry_obj">0</field>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionBlob</field>
                 <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="sentry_obj">0</field>
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="sentry_obj">0</field>
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionBlob</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="sentry_obj">0</field>
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                            <next>
-                              <block type="SentrySetZoom">
-                                <field name="sentry_obj">0</field>
-                                <field name="zoom_obj">kZoom1</field>
-                                <next>
-                                  <block type="SentryVisionSetParamNum">
-                                    <field name="sentry_obj">0</field>
-                                    <field name="vision_obj">Sentry2::kVisionBlob</field>
-                                    <field name="num">2</field>
-                                    <next>
-                                      <block type="SentryVisionBlobSetParam">
-                                        <field name="sentry_obj">0</field>
-                                        <field name="vision_obj">Sentry2::kVisionBlob</field>
-                                        <field name="w">20</field>
-                                        <field name="h">20</field>
-                                        <field name="lable">Sentry2::kColorGreen</field>
-                                        <field name="index">0</field>
-                                        <next>
-                                          <block type="SentryVisionBlobSetParam">
-                                            <field name="sentry_obj">0</field>
-                                            <field name="vision_obj">Sentry2::kVisionBlob</field>
-                                            <field name="w">20</field>
-                                            <field name="h">20</field>
-                                            <field name="lable">Sentry2::kColorRed</field>
-                                            <field name="index">1</field>
-                                          </block>
-                                        </next>
-                                      </block>
-                                    </next>
-                                  </block>
-                                </next>
-                              </block>
-                            </next>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
+                  <block type="SentrySetAWB" id="SI9X@Zeca!WyrnE$kc_s">
+                    <field name="awb_obj">kWhiteLight</field>
                   </block>
                 </next>
               </block>
@@ -778,36 +447,242 @@
         </next>
       </block>
     </category>
-    <category id="Sentry_example_AprilTag" name="AprilTag" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+    <category id="Sentry_example_Color" name="颜色识别" colour="#EAA20A">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="329" y="125">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionColor</field>
                 <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionAprilTag</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
+                  <block type="SentrySetAWB" id="SI9X@Zeca!WyrnE$kc_s">
+                    <field name="awb_obj">kWhiteLight</field>
+                  </block>
+                </next>
+              </block>
+            </next>
+          </block>
+        </statement>
+      </block>
+      <block type="variables_declare">
+        <field name="variables_type">local_variate</field>
+        <field name="VAR">count</field>
+        <field name="TYPE">int</field>
+        <value name="VALUE">
+          <block type="math_number">
+            <field name="NUM">0</field>
+          </block>
+        </value>
+        <next>
+          <block type="variables_set">
+            <field name="VAR">count</field>
+            <value name="VALUE">
+              <block type="SentryVisionDetectedCount">
+                <field name="sentry_obj">0</field>
+                <field name="vision_obj">Sentry2::kVisionColor</field>
+              </block>
+            </value>
+            <next>
+              <block type="controls_for">
+                <field name="VAR">i</field>
+                <value name="FROM">
+                  <shadow type="math_number">
+                    <field name="NUM">0</field>
+                  </shadow>
+                </value>
+                <value name="TO">
+                  <shadow type="math_number">
+                    <field name="NUM">10</field>
+                  </shadow>
+                  <block type="math_arithmetic">
+                    <field name="OP">MINUS</field>
+                    <value name="A">
+                      <shadow type="math_number">
+                        <field name="NUM">1</field>
+                      </shadow>
+                      <block type="variables_get">
+                        <field name="VAR">count</field>
+                      </block>
+                    </value>
+                    <value name="B">
+                      <shadow type="math_number">
+                        <field name="NUM">1</field>
+                      </shadow>
+                    </value>
+                  </block>
+                </value>
+                <value name="STEP">
+                  <shadow type="math_number">
+                    <field name="NUM">1</field>
+                  </shadow>
+                </value>
+                <statement name="DO">
+                  <block type="serial_print">
+                    <field name="serial_select">Serial</field>
+                    <field name="new_line">println</field>
+                    <value name="CONTENT">
+                      <block type="text_join">
+                        <value name="A">
+                          <shadow type="text">
+                            <field name="TEXT">r=</field>
+                          </shadow>
+                        </value>
+                        <value name="B">
+                          <shadow type="text">
+                            <field name="TEXT">Mixly</field>
+                          </shadow>
+                          <block type="SentryGetValue">
+                            <field name="sentry_obj">0</field>
+                            <value name="sentry_value_obj">
+                              <block type="SentryVisionObjColor">
+                                <field name="vision_obj">Sentry2::kVisionColor</field>
+                                <field name="vision_res_obj">kRValue</field>
+                              </block>
+                            </value>
+                            <value name="index">
                               <shadow type="math_number">
-                                <field name="NUM">2</field>
+                                <field name="NUM">0</field>
+                              </shadow>
+                              <block type="variables_get">
+                                <field name="VAR">i</field>
+                              </block>
+                            </value>
+                          </block>
+                        </value>
+                      </block>
+                    </value>
+                    <next>
+                      <block type="serial_print">
+                        <field name="serial_select">Serial</field>
+                        <field name="new_line">println</field>
+                        <value name="CONTENT">
+                          <block type="text_join">
+                            <value name="A">
+                              <shadow type="text">
+                                <field name="TEXT">g=</field>
                               </shadow>
                             </value>
+                            <value name="B">
+                              <shadow type="text">
+                                <field name="TEXT">Mixly</field>
+                              </shadow>
+                              <block type="SentryGetValue">
+                                <field name="sentry_obj">0</field>
+                                <value name="sentry_value_obj">
+                                  <block type="SentryVisionObjColor">
+                                    <field name="vision_obj">Sentry2::kVisionColor</field>
+                                    <field name="vision_res_obj">kGValue</field>
+                                  </block>
+                                </value>
+                                <value name="index">
+                                  <shadow type="math_number">
+                                    <field name="NUM">0</field>
+                                  </shadow>
+                                  <block type="variables_get">
+                                    <field name="VAR">i</field>
+                                  </block>
+                                </value>
+                              </block>
+                            </value>
+                          </block>
+                        </value>
+                        <next>
+                          <block type="serial_print">
+                            <field name="serial_select">Serial</field>
+                            <field name="new_line">println</field>
+                            <value name="CONTENT">
+                              <block type="text_join">
+                                <value name="A">
+                                  <shadow type="text">
+                                    <field name="TEXT">b=</field>
+                                  </shadow>
+                                </value>
+                                <value name="B">
+                                  <shadow type="text">
+                                    <field name="TEXT">Mixly</field>
+                                  </shadow>
+                                  <block type="SentryGetValue">
+                                    <field name="sentry_obj">0</field>
+                                    <value name="sentry_value_obj">
+                                      <block type="SentryVisionObjColor">
+                                        <field name="vision_obj">Sentry2::kVisionColor</field>
+                                        <field name="vision_res_obj">kBValue</field>
+                                      </block>
+                                    </value>
+                                    <value name="index">
+                                      <shadow type="math_number">
+                                        <field name="NUM">0</field>
+                                      </shadow>
+                                      <block type="variables_get">
+                                        <field name="VAR">i</field>
+                                      </block>
+                                    </value>
+                                  </block>
+                                </value>
+                              </block>
+                            </value>
+                            <next>
+                              <block type="serial_print">
+                                <field name="serial_select">Serial</field>
+                                <field name="new_line">println</field>
+                                <value name="CONTENT">
+                                  <block type="text_join">
+                                    <value name="A">
+                                      <shadow type="text">
+                                        <field name="TEXT">l=</field>
+                                      </shadow>
+                                    </value>
+                                    <value name="B">
+                                      <shadow type="text">
+                                        <field name="TEXT">Mixly</field>
+                                      </shadow>
+                                      <block type="SentryGetValue">
+                                        <field name="sentry_obj">0</field>
+                                        <value name="sentry_value_obj">
+                                          <block type="SentryVisionObjColor">
+                                            <field name="vision_obj">Sentry2::kVisionColor</field>
+                                            <field name="vision_res_obj">kLabel</field>
+                                          </block>
+                                        </value>
+                                        <value name="index">
+                                          <shadow type="math_number">
+                                            <field name="NUM">0</field>
+                                          </shadow>
+                                          <block type="variables_get">
+                                            <field name="VAR">i</field>
+                                          </block>
+                                        </value>
+                                      </block>
+                                    </value>
+                                  </block>
+                                </value>
+                              </block>
+                            </next>
                           </block>
                         </next>
                       </block>
                     </next>
                   </block>
-                </next>
+                </statement>
+              </block>
+            </next>
+          </block>
+        </next>
+      </block>
+    </category>
+    <category id="Sentry_example_AprilTag" name="AprilTag" colour="#EAA20A">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
+            <field name="mode_obj">Wire</field>
+            <field name="addr_obj">0x60</field>
+            <next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionAprilTag</field>
               </block>
             </next>
           </block>
@@ -1051,35 +926,15 @@
       </block>
     </category>
     <category id="Sentry_example_Line" name="线段检测" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionLine</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionLine</field>
               </block>
             </next>
           </block>
@@ -1323,35 +1178,15 @@
       </block>
     </category>
     <category id="Sentry_example_Learning" name="深度学习" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionLearning</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionLearning</field>
               </block>
             </next>
           </block>
@@ -1559,35 +1394,15 @@
       </block>
     </category>
     <category id="Sentry_example_Card" name="卡片识别" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionCard</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionCard</field>
               </block>
             </next>
           </block>
@@ -1905,35 +1720,15 @@
       </block>
     </category>
     <category id="Sentry_example_Face" name="人脸识别" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionFace</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionFace</field>
               </block>
             </next>
           </block>
@@ -2177,35 +1972,15 @@
       </block>
     </category>
     <category id="Sentry_example_20Class" name="20分类识别" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVision20Classes</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVision20Classes</field>
               </block>
             </next>
           </block>
@@ -2523,39 +2298,15 @@
       </block>
     </category>
     <category id="Sentry_example_Qr" name="二维码识别" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
-            <field name="sentry_obj">0</field>
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
+            <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <field name="sentry_obj">0</field>
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="sentry_obj">0</field>
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="sentry_obj">0</field>
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionQrCode</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="sentry_obj">0</field>
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">1</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionQrCode</field>
               </block>
             </next>
           </block>
@@ -2734,35 +2485,15 @@
       </block>
     </category>
     <category id="Sentry_example_MotionDetect" name="运动物体检测" colour="#EAA20A">
-      <block type="SentrySetup">
-        <statement name="SENTRY_SETUP_BLOCK">
-          <block type="SentryBegin">
+      <block type="base_setup" id="RMc:iUOUCmgXMP^D^*hS" x="623" y="94">
+        <statement name="DO">
+          <block type="SentryBegin" id="uIuOd^FP?*0zG:o=4mLL">
             <field name="mode_obj">Wire</field>
             <field name="addr_obj">0x60</field>
             <next>
-              <block type="SentrySetDefault">
-                <next>
-                  <block type="SentrySetCoordinateType">
-                    <field name="coord_obj">kAbsoluteCoordinate</field>
-                    <next>
-                      <block type="SentryVisionSetStatus">
-                        <field name="VisionStatus">Begin</field>
-                        <field name="vision_obj">Sentry2::kVisionMotionDetect</field>
-                        <next>
-                          <block type="SentryLedSetColor">
-                            <field name="led_color_obj1">#0000ff</field>
-                            <field name="led_color_obj2">#ff0000</field>
-                            <value name="level">
-                              <shadow type="math_number">
-                                <field name="NUM">2</field>
-                              </shadow>
-                            </value>
-                          </block>
-                        </next>
-                      </block>
-                    </next>
-                  </block>
-                </next>
+              <block type="SentryVisionSetStatus" id="Ul:{s8J9I8OsPTm,vUKu">
+                <field name="VisionStatus">Begin</field>
+                <field name="vision_obj">Sentry2::kVisionMotionDetect</field>
               </block>
             </next>
           </block>

--- a/block/Sentry.js
+++ b/block/Sentry.js
@@ -164,25 +164,25 @@ var vision_obj_card_dict = {
   "Sentry2::kVision20Classes": vision_20class_objs
 }
 
-Blockly.Blocks['SentrySetup'] = {
-  init: function () {
-    this.setColour(Blockly.Blocks.Sentry.SetupMode_Color);
-    this.appendDummyInput()
-      .appendField(Blockly.Msg.SENTRY_SET_UP)
-    this.appendStatementInput('SENTRY_SETUP_BLOCK');
-    this.setPreviousStatement(true, null);
-    this.setNextStatement(true, null);
-  },
+// Blockly.Blocks['SentrySetup'] = {
+//   init: function () {
+//     this.setColour(Blockly.Blocks.Sentry.SetupMode_Color);
+//     this.appendDummyInput()
+//       .appendField(Blockly.Msg.SENTRY_SET_UP)
+//     this.appendStatementInput('SENTRY_SETUP_BLOCK');
+//     this.setPreviousStatement(true, null);
+//     this.setNextStatement(true, null);
+//   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'base_setup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_BASE);
-    }
-  }
-};
+//   onchange: function (e) {
+//     var surround_parent = this.getSurroundParent();
+//     if (surround_parent && surround_parent.type == 'base_setup') {
+//       this.setWarningText(null);
+//     } else {
+//       this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_BASE);
+//     }
+//   }
+// };
 
 Blockly.Blocks['SentryBegin'] = {
   init: function () {
@@ -205,14 +205,14 @@ Blockly.Blocks['SentryBegin'] = {
     this.setHelpUrl();
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 // 恢复默认设置
@@ -228,14 +228,14 @@ Blockly.Blocks["SentrySetDefault"] = {
     this.setTooltip(Blockly.Msg.SENTRY_HELP_SET_DEFAULT);
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 // 坐标系设置
@@ -252,14 +252,14 @@ Blockly.Blocks["SentrySetCoordinateType"] = {
     this.setTooltip(Blockly.Msg.SENTRY_HELP_SET_COORDINATE);
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 // 启用算法
@@ -295,14 +295,14 @@ Blockly.Blocks["SentryVisionSetParamNum"] = {
     this.setColour(Blockly.Blocks.Sentry.SetupMode_Color);
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 Blockly.Blocks['SentryVisionColorSetParam'] = {
@@ -329,14 +329,14 @@ Blockly.Blocks['SentryVisionColorSetParam'] = {
     this.setColour(Blockly.Blocks.Sentry.SetupMode_Color);
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 Blockly.Blocks['SentryVisionBlobSetParam'] = {
@@ -361,14 +361,14 @@ Blockly.Blocks['SentryVisionBlobSetParam'] = {
     this.setColour(Blockly.Blocks.Sentry.SetupMode_Color);
   },
 
-  onchange: function (e) {
-    var surround_parent = this.getSurroundParent();
-    if (surround_parent && surround_parent.type == 'SentrySetup') {
-      this.setWarningText(null);
-    } else {
-      this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
-    }
-  }
+  // onchange: function (e) {
+  //   var surround_parent = this.getSurroundParent();
+  //   if (surround_parent && surround_parent.type == 'SentrySetup') {
+  //     this.setWarningText(null);
+  //   } else {
+  //     this.setWarningText(Blockly.Msg.SENTRY_WARNING_SETUP_ONLY);
+  //   }
+  // }
 };
 
 Blockly.Blocks["SentryLedSetColor"] = {

--- a/language/Sentry/en.js
+++ b/language/Sentry/en.js
@@ -2,8 +2,8 @@
 goog. provide('Blockly.Msg.zh.hans');
 goog. require('Blockly.Msg');
 
-Blockly.Msg.CATEGORY_MORPX_SENTRY_Setup = 'setting module';
-Blockly.Msg.CATEGORY_MORPX_SENTRY_RUN = 'running module';
+Blockly.Msg.CATEGORY_SENTRY_Setup = 'setting module';
+Blockly.Msg.CATEGORY_SENTRY_RUN = 'running module';
 
 //Help text
 Blockly.Msg.SENTRY_HELP_INIT_TOOLTIP = 'initialize the vision sensor and select the relevant address';

--- a/language/Sentry/zh-hans.js
+++ b/language/Sentry/zh-hans.js
@@ -2,8 +2,8 @@
 goog.provide('Blockly.Msg.zh.hans');
 goog.require('Blockly.Msg');
 
-Blockly.Msg.CATEGORY_MORPX_SENTRY_SETUP = '设置模块';
-Blockly.Msg.CATEGORY_MORPX_SENTRY_RUN = '运行模块';
+Blockly.Msg.CATEGORY_SENTRY_SETUP = '设置模块';
+Blockly.Msg.CATEGORY_SENTRY_RUN = '运行模块';
 
 // Help文本
 Blockly.Msg.SENTRY_HELP_INIT_TOOLTIP = '初始化视觉传感器，并选择相关的地址';
@@ -28,7 +28,7 @@ Blockly.Msg.SENTRY_ADDR = '地址';
 Blockly.Msg.SENTRY_SET_DEFAULT = ' 恢复默认参数';
 Blockly.Msg.SENTRY_VISION = '算法';
 Blockly.Msg.SENTRY_STATUS = '状态';
-Blockly.Msg.SENTRY_SET = '设置';
+Blockly.Msg.SENTRY_SET = '设置 ';
 Blockly.Msg.SENTRY_SET_COORDINATE = '坐标输出';
 Blockly.Msg.SENTRY_SET_PARAMNUM = '参数个数';
 Blockly.Msg.SENTRY_SET_PARAM = '参数';
@@ -39,7 +39,7 @@ Blockly.Msg.SENTRY_Y = '纵坐标';
 Blockly.Msg.SENTRY_LEAST = '最小检测';
 Blockly.Msg.SENTRY_WEIGHT = '宽度';
 Blockly.Msg.SENTRY_HIGH = '高度'
-Blockly.Msg.SENTRY_LABLE = '标签';  
+Blockly.Msg.SENTRY_LABLE = '标签';
 Blockly.Msg.SENTRY_LED_SET_COLOR = 'LED检测到结果颜色为';
 Blockly.Msg.SENTRY_LED_SET_COLOR_NOT = '否则'
 Blockly.Msg.SENTRY_LED_SET_LEVEL = '亮度(0~15)';

--- a/language/Sentry/zh-hant.js
+++ b/language/Sentry/zh-hant.js
@@ -1,8 +1,8 @@
 'use strict';
 goog. provide('Blockly.Msg.zh.hans');
 goog. require('Blockly.Msg');
-Blockly.Msg.CATEGORY_MORPX_SENTRY_SETUP = '設定模塊';
-Blockly.Msg.CATEGORY_MORPX_SENTRY_RUN = '運行模塊';
+Blockly.Msg.CATEGORY_SENTRY_SETUP = '設定模塊';
+Blockly.Msg.CATEGORY_SENTRY_RUN = '運行模塊';
 // Help文字
 Blockly.Msg.SENTRY_HELP_INIT_TOOLTIP = '初始化視覺感測器，並選擇相關的地址';
 Blockly.Msg.SENTRY_HELP_SET_DEFAULT = '感測器算灋狀態恢復默認';


### PR DESCRIPTION
1. Fix typo; 
2. Simplify examples; 
3. Remove useless block `SentrySetup`; 
4. Delete warning while block not initialize under the block `SentrySetup`
5. FIxed bug in block `SentryLedSetColor`

@Uniquemf 